### PR TITLE
fix: client_auth: unquote clientID and secret with Basic auth

### DIFF
--- a/src/pyop/client_authentication.py
+++ b/src/pyop/client_authentication.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+from urllib.parse import unquote
 
 from .exceptions import InvalidClientAuthentication
 
@@ -35,7 +36,7 @@ def verify_client_authentication(clients, parsed_request, authz_header=None):
                 auth = base64.urlsafe_b64decode(credentials.encode('utf-8')).decode('utf-8')
             except UnicodeDecodeError as e:
                 raise InvalidClientAuthentication('Could not userid/password from authorization header'.format(authz_scheme))
-            client_id, client_secret = auth.split(':')
+            client_id, client_secret = [unquote(part) for part in auth.split(':')]
         else:
             raise InvalidClientAuthentication('Unknown scheme in authorization header, {} != Basic'.format(authz_scheme))
     elif 'client_id' in parsed_request:


### PR DESCRIPTION
Hi @c00kiemon5ter ,

I've run into an issue with clientID and secret encoding when using Basic auth.

With Basic auth, clientID and secret should be URI-encoded before used as username and password to form the Basic auth header:

https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1

Existing OpenIDConnect implementations follow the standard and encode the clientID and secret ... and the client authentication for the token endpoint then fails with either
`pyop.exceptions.InvalidClientAuthentication: Incorrect client_secret`
or
`pyop.exceptions.InvalidClientAuthentication: client_id '1621892763.....%2B%2F' unknown`

- when characters like '+' or '/' are used in either the clientID or secret.

This happens only for `client_secret_basic` - but not for `client_secret_post`.

Fix this by explicitly URI-decoding the clientID and secret extracted from the Basic auth header (but only in this flow).

Hope this fix can be easily merged - please let me know if I need to clarify anything.

Cheers,
Vlad
