### PR TITLE
Add pkce support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ user data and OpenID Connect claim names. Hence the underlying data source must 
 same names as the [standard claims of OpenID Connect](http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims).
 
 ```python
-from oic.oic.message import AuthorizationRequest
+from pyop.message import AuthorizationRequest
 
 from pyop.util import should_fragment_encode
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description='OpenID Connect Provider (OP) library in Python.',
     install_requires=[
         'oic >= 1.2.1',
-        'nacl',
+        'pynacl',
         'pymongo'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     description='OpenID Connect Provider (OP) library in Python.',
     install_requires=[
         'oic >= 1.2.1',
-        'pynacl',
         'pymongo'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     description='OpenID Connect Provider (OP) library in Python.',
     install_requires=[
         'oic >= 1.2.1',
+        'nacl',
         'pymongo'
     ]
 )

--- a/src/pyop/authz_state.py
+++ b/src/pyop/authz_state.py
@@ -3,8 +3,8 @@ import time
 import uuid
 
 from oic.extension.message import TokenIntrospectionResponse
-from oic.oic.message import AuthorizationRequest
 
+from .message import AuthorizationRequest
 from .access_token import AccessToken
 from .exceptions import InvalidAccessToken
 from .exceptions import InvalidAuthorizationCode
@@ -80,7 +80,7 @@ class AuthorizationState(object):
         self.subject_identifiers = subject_identifier_db if subject_identifier_db is not None else {}
 
     def create_authorization_code(self, authorization_request, subject_identifier, scope=None):
-        # type: (oic.oic.message.AuthorizationRequest, str, Optional[List[str]]) -> str
+        # type: (AuthorizationRequest, str, Optional[List[str]]) -> str
         """
         Creates an authorization code bound to the authorization request and the authenticated user identified
         by the subject identifier.
@@ -106,7 +106,7 @@ class AuthorizationState(object):
         return authorization_code
 
     def create_access_token(self, authorization_request, subject_identifier, scope=None):
-        # type: (oic.oic.message.AuthorizationRequest, str, Optional[List[str]]) -> se_leg_op.access_token.AccessToken
+        # type: (AuthorizationRequest, str, Optional[List[str]]) -> se_leg_op.access_token.AccessToken
         """
         Creates an access token bound to the authentication request and the authenticated user identified by the
         subject identifier.
@@ -315,7 +315,7 @@ class AuthorizationState(object):
         raise InvalidSubjectIdentifier('{} unknown'.format(subject_identifier))
 
     def get_authorization_request_for_code(self, authorization_code):
-        # type: (str) -> oic.oic.message.AuthorizationRequest
+        # type: (str) -> AuthorizationRequest
         if authorization_code not in self.authorization_codes:
             raise InvalidAuthorizationCode('{} unknown'.format(authorization_code))
 
@@ -323,14 +323,14 @@ class AuthorizationState(object):
             self.authorization_codes[authorization_code][self.KEY_AUTHORIZATION_REQUEST])
 
     def get_authorization_request_for_access_token(self, access_token_value):
-        # type: (str) -> oic.oic.message.AuthorizationRequest
+        # type: (str) -> 
         if access_token_value not in self.access_tokens:
             raise InvalidAccessToken('{} unknown'.format(access_token_value))
 
         return AuthorizationRequest().from_dict(self.access_tokens[access_token_value][self.KEY_AUTHORIZATION_REQUEST])
 
     def get_subject_identifier_for_code(self, authorization_code):
-        # type: (str) -> oic.oic.message.AuthorizationRequest
+        # type: (str) -> AuthorizationRequest
         if authorization_code not in self.authorization_codes:
             raise InvalidAuthorizationCode('{} unknown'.format(authorization_code))
 

--- a/src/pyop/message.py
+++ b/src/pyop/message.py
@@ -1,7 +1,7 @@
 from oic.oauth2.message import SINGLE_OPTIONAL_STRING
 from oic.oic import message
 
-class AccessTokenRequest(message.Message):
+class AccessTokenRequest(message.AccessTokenRequest):
     c_param = message.AccessTokenRequest.c_param.copy()
     c_param.update(
         {
@@ -9,7 +9,7 @@ class AccessTokenRequest(message.Message):
         }
     )
 
-class AuthorizationRequest(message.Message):
+class AuthorizationRequest(message.AuthorizationRequest):
     c_param = message.AuthorizationRequest.c_param.copy()
     c_param.update(
         {

--- a/src/pyop/message.py
+++ b/src/pyop/message.py
@@ -18,7 +18,7 @@ class AuthorizationRequest(message.Message):
         }
     )
 
-    c_allowed_values = message.AuthorizationRequest.c_param.copy()
+    c_allowed_values = message.AuthorizationRequest.c_allowed_values.copy()
     c_allowed_values.update(
         {
         "code_challenge_method": [

--- a/src/pyop/message.py
+++ b/src/pyop/message.py
@@ -1,0 +1,29 @@
+from oic.oauth2.message import SINGLE_OPTIONAL_STRING
+from oic.oic import message
+
+class AccessTokenRequest(message.Message):
+    c_param = message.AccessTokenRequest.c_param.copy()
+    c_param.update(
+        {
+            'code_verifier': SINGLE_OPTIONAL_STRING
+        }
+    )
+
+class AuthorizationRequest(message.Message):
+    c_param = message.AuthorizationRequest.c_param.copy()
+    c_param.update(
+        {
+            'code_challenge': SINGLE_OPTIONAL_STRING,
+            'code_challenge_method': SINGLE_OPTIONAL_STRING
+        }
+    )
+
+    c_allowed_values = message.AuthorizationRequest.c_param.copy()
+    c_allowed_values.update(
+        {
+        "code_challenge_method": [
+                "plain",
+                "S256"
+            ]
+        }
+    )

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -361,6 +361,13 @@ class Provider(object):
         :param authentication_request: the code_verfier to check against the code challenge.
         :returns: whether the code_verifier is what was expected given the cc_cm
         """
+        if not 'code_verifier' in token_request:
+            return False
+
+        if not 'code_challenge_method' in authentication_request:
+            raise InvalidTokenRequest("A code_challenge and code_verifier have been supplied" 
+                                      "but missing code_challenge_method in authentication_request", token_request)
+
         code_challenge_method = authentication_request['code_challenge_method']
         if code_challenge_method == 'plain':
             return authentication_request['code_challenge'] == token_request['code_verifier']

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -83,7 +83,7 @@ class Provider(object):
         self.userinfo = userinfo
         self.id_token_lifetime = id_token_lifetime
 
-        self.authentication_request_validators = []  # type: List[Callable[[oic.oic.message.AuthorizationRequest], Boolean]]
+        self.authentication_request_validators = []  # type: List[Callable[[AuthorizationRequest], Boolean]]
         self.authentication_request_validators.append(authorization_request_verify)
         self.authentication_request_validators.append(
             functools.partial(client_id_is_known, self))
@@ -116,7 +116,7 @@ class Provider(object):
         return {'keys': keys}
 
     def parse_authentication_request(self, request_body, http_headers=None):
-        # type: (str, Optional[Mapping[str, str]]) -> oic.oic.message.AuthorizationRequest
+        # type: (str, Optional[Mapping[str, str]]) -> AuthorizationRequest
         """
         Parses and verifies an authentication request.
 
@@ -132,7 +132,7 @@ class Provider(object):
         logger.debug('parsed authentication_request: %s', auth_req)
         return auth_req
 
-    def authorize(self, authentication_request,  # type: oic.oic.message.AuthorizationRequest
+    def authorize(self, authentication_request,  # type: AuthorizationRequest
                   user_id,  # type: str
                   extra_id_token_claims=None
                   # type: Optional[Union[Mapping[str, Union[str, List[str]]], Callable[[str, str], Mapping[str, Union[str, List[str]]]]]
@@ -218,7 +218,7 @@ class Provider(object):
         return self.authz_state.get_subject_identifier(subject_type, user_id, sector_identifier)
 
     def _get_requested_claims_in(self, authentication_request, response_method):
-        # type (oic.oic.message.AuthorizationRequest, str) -> Mapping[str, Optional[Mapping[str, Union[str, List[str]]]]
+        # type (AuthorizationRequest, str) -> Mapping[str, Optional[Mapping[str, Union[str, List[str]]]]
         """
         Parses any claims requested using the 'claims' request parameter, see
         <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">
@@ -286,7 +286,7 @@ class Provider(object):
         return id_token.to_jwt([self.signing_key], alg)
 
     def _check_subject_identifier_matches_requested(self, authentication_request, sub):
-        # type (oic.message.AuthorizationRequest, str) -> None
+        # type (AuthorizationRequest, str) -> None
         """
         Verifies the subject identifier against any requested subject identifier using the claims request parameter.
         :param authentication_request: authentication request

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -381,7 +381,7 @@ class Provider(object):
         :param token_request: The request asking for a token given a code, and optionally a code_verifier
         :param authentication_request: The authentication request belonging to the provided code.
         :raises InvalidTokenRequest, InvalidAuthorizationCode: If request is invalid, throw a representing exception. 
-        """ 
+        """
         if token_request['client_id'] != authentication_request['client_id']:
             logger.info('Authorization code \'%s\' belonging to \'%s\' was used by \'%s\'',
                         token_request['code'], authentication_request['client_id'], token_request['client_id'])
@@ -391,7 +391,8 @@ class Provider(object):
                                                                               authentication_request['redirect_uri']),
                                       token_request)
         if 'code_challenge' in authentication_request and not self._PKCE_verify(token_request, authentication_request):
-            raise InvalidTokenRequest('Unexpected Code Verifier: {}'.format(authentication_request['code_challenge']))
+            raise InvalidTokenRequest('Unexpected Code Verifier: {}'.format(authentication_request['code_challenge']),
+                                      token_request)
 
     def _do_code_exchange(self, request,  # type: Dict[str, str]
                           extra_id_token_claims=None

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -459,7 +459,7 @@ class Provider(object):
         Handles a token request for refreshing an access token (grant_type=refresh_token).
         :param request: parsed http request parameters
         :return: a token response containing a new Access Token and possibly a new Refresh Token
-        :raise InvalidTtoken_requestokenRequest: if the token request is invalid
+        :raise InvalidTokenRequest: if the token request is invalid
         """
         token_request = RefreshAccessTokenRequest().from_dict(request)
         try:

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -370,7 +370,7 @@ class Provider(object):
             raise InvalidTokenRequest('Invalid redirect_uri: {} != {}'.format(token_request['redirect_uri'],
                                                                               authentication_request['redirect_uri']),
                                       token_request)
-        if not self._PKCE_verify(token_request, authentication_request):
+        if 'code_challenge' in authentication_request and not self._PKCE_verify(token_request, authentication_request):
             raise InvalidTokenRequest('Unexpected Code Verifier: {}'.format(authentication_request['code_challenge']))
 
     def _do_code_exchange(self, request,  # type: Dict[str, str]

--- a/tests/pyop/test_authz_state.py
+++ b/tests/pyop/test_authz_state.py
@@ -4,8 +4,8 @@ import time
 from unittest.mock import patch, Mock
 
 import pytest
-from oic.oic.message import AuthorizationRequest
 
+from pyop.message import AuthorizationRequest
 from pyop.authz_state import AccessToken, InvalidScope
 from pyop.authz_state import AuthorizationState
 from pyop.exceptions import InvalidSubjectIdentifier, InvalidAccessToken, InvalidAuthorizationCode, InvalidRefreshToken

--- a/tests/pyop/test_exceptions.py
+++ b/tests/pyop/test_exceptions.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlparse, parse_qsl
 
-from oic.oic.message import AuthorizationRequest
-
+from pyop.message import AuthorizationRequest
 from pyop.exceptions import InvalidAuthenticationRequest
 
 

--- a/tests/pyop/test_provider.py
+++ b/tests/pyop/test_provider.py
@@ -332,6 +332,20 @@ class TestProviderHandleTokenRequest(object):
         assert response['access_token'] in self.provider.authz_state.access_tokens
         assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
                                     self.authn_request_args)
+
+    @patch('time.time', MOCK_TIME)
+    def test_pkce_code_exchange_request_plaintext(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
+            {
+                "code_challenge": "SoOEDN-mZKNhw7Mc52VXxyiqTvFB3mod36MwPru253c",
+                "code_challenge_method": "plain"
+            }
+        )
+        self.authorization_code_exchange_request_args['code_verifier'] = "SoOEDN-mZKNhw7Mc52VXxyiqTvFB3mod36MwPru253c"
+        response = self.provider._do_code_exchange(self.authorization_code_exchange_request_args, None)
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
+                                    self.authn_request_args)
     @patch('time.time', MOCK_TIME)
     def test_code_exchange_request_with_claims_requested_in_id_token(self):
         claims_req = {'claims': ClaimsRequest(id_token=Claims(email=None))}
@@ -389,8 +403,13 @@ class TestProviderHandleTokenRequest(object):
             self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
 
     def test_handle_token_request_reject_invalid_code_verifier(self):
-        del self.authorization_code_exchange_request_args['grant_type']
-        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
+            {
+                "code_challenge": "_1f8tFjAtu6D1Df-GOyDPoMjCJdEvaSWsnqR6SLpzsw=",
+                "code_challenge_method": "S256"
+            }
+        )
+        self.authorization_code_exchange_request_args['code_verifier'] = "ThiS Cer_tainly Ain't Valid"
         with pytest.raises(InvalidTokenRequest):
             self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
 

--- a/tests/pyop/test_provider.py
+++ b/tests/pyop/test_provider.py
@@ -334,20 +334,6 @@ class TestProviderHandleTokenRequest(object):
                                     self.authn_request_args)
 
     @patch('time.time', MOCK_TIME)
-    def test_pkce_code_exchange_request_plaintext(self):
-        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
-            {
-                "code_challenge": "SoOEDN-mZKNhw7Mc52VXxyiqTvFB3mod36MwPru253c",
-                "code_challenge_method": "plain"
-            }
-        )
-        self.authorization_code_exchange_request_args['code_verifier'] = "SoOEDN-mZKNhw7Mc52VXxyiqTvFB3mod36MwPru253c"
-        response = self.provider._do_code_exchange(self.authorization_code_exchange_request_args, None)
-        assert response['access_token'] in self.provider.authz_state.access_tokens
-        assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
-                                    self.authn_request_args)
-
-    @patch('time.time', MOCK_TIME)
     def test_code_exchange_request_with_claims_requested_in_id_token(self):
         claims_req = {'claims': ClaimsRequest(id_token=Claims(email=None))}
         self.authorization_code_exchange_request_args['code'] = self.create_authz_code(extra_auth_req_params=claims_req)

--- a/tests/pyop/test_provider.py
+++ b/tests/pyop/test_provider.py
@@ -12,8 +12,9 @@ from jwkest.jwk import RSAKey
 from oic import rndstr
 from oic.oauth2.message import MissingRequiredValue, MissingRequiredAttribute
 from oic.oic import PREFERENCE2PROVIDER
-from oic.oic.message import IdToken, AuthorizationRequest, ClaimsRequest, Claims, EndSessionRequest, EndSessionResponse
+from oic.oic.message import IdToken, ClaimsRequest, Claims, EndSessionRequest, EndSessionResponse
 
+from pyop.message import AuthorizationRequest
 from pyop.access_token import BearerTokenError
 from pyop.authz_state import AuthorizationState
 from pyop.client_authentication import InvalidClientAuthentication
@@ -319,6 +320,19 @@ class TestProviderHandleTokenRequest(object):
                                     self.authn_request_args)
 
     @patch('time.time', MOCK_TIME)
+    def test_pkce_code_exchange_request(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
+            {
+                "code_challenge": "_1f8tFjAtu6D1Df-GOyDPoMjCJdEvaSWsnqR6SLpzsw",
+                "code_challenge_method": "S256"
+            }
+        )
+        self.authorization_code_exchange_request_args['code_verifier'] = "SoOEDN-mZKNhw7Mc52VXxyiqTvFB3mod36MwPru253c"
+        response = self.provider._do_code_exchange(self.authorization_code_exchange_request_args, None)
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
+                                    self.authn_request_args)
+    @patch('time.time', MOCK_TIME)
     def test_code_exchange_request_with_claims_requested_in_id_token(self):
         claims_req = {'claims': ClaimsRequest(id_token=Claims(email=None))}
         self.authorization_code_exchange_request_args['code'] = self.create_authz_code(extra_auth_req_params=claims_req)
@@ -369,6 +383,12 @@ class TestProviderHandleTokenRequest(object):
             self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
 
     def test_handle_token_request_reject_missing_grant_type(self):
+        del self.authorization_code_exchange_request_args['grant_type']
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        with pytest.raises(InvalidTokenRequest):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_handle_token_request_reject_invalid_code_verifier(self):
         del self.authorization_code_exchange_request_args['grant_type']
         self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
         with pytest.raises(InvalidTokenRequest):

--- a/tests/pyop/test_util.py
+++ b/tests/pyop/test_util.py
@@ -1,6 +1,6 @@
 import pytest
-from oic.oic.message import AuthorizationRequest
 
+from pyop.message import AuthorizationRequest
 from pyop.util import should_fragment_encode
 
 


### PR DESCRIPTION
Add PKCE support when requested by the client. Used reference is displayed in RFC 7636. Only for the authorization_code flow.

https://datatracker.ietf.org/doc/html/rfc7636

New requests optionally include the query parameters: `code_challenge` and `code_challenge_method` on the  initial `authorize` request, then on `token_endpoint` it is required to contain a `code_verifier` parameter containing the code_verifier used to create the hash passed earlier as `code_challenge`.