### PR TITLE
Feature request: allow extra options for storage backends

### DIFF
--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -120,10 +120,10 @@ class RedisWrapper(StorageBase):
     Supports JSON-serializable data types.
     """
 
-    def __init__(self, db_uri, collection, ttl=None):
+    def __init__(self, db_uri, collection, ttl=None, options=None):
         if not _has_redis:
             raise ImportError("redis module is required but it is not available")
-        self._db = Redis.from_url(db_uri, decode_responses=True)
+        self._db = Redis.from_url(db_uri, decode_responses=True, **options.get('redis_kwargs', {}))
         self._collection = collection
         if ttl is None or (isinstance(ttl, int) and ttl >= 0):
             self._ttl = ttl

--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -121,6 +121,9 @@ class RedisWrapper(StorageBase):
     """
 
     def __init__(self, db_uri, collection, ttl=None, options={}):
+        if options is None:
+            options = {}
+
         if not _has_redis:
             raise ImportError("redis module is required but it is not available")
         self._db = Redis.from_url(db_uri, decode_responses=True, **options.get('redis_kwargs', {}))

--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -120,7 +120,7 @@ class RedisWrapper(StorageBase):
     Supports JSON-serializable data types.
     """
 
-    def __init__(self, db_uri, collection, ttl=None, options=None):
+    def __init__(self, db_uri, collection, ttl=None, options={}):
         if not _has_redis:
             raise ImportError("redis module is required but it is not available")
         self._db = Redis.from_url(db_uri, decode_responses=True, **options.get('redis_kwargs', {}))


### PR DESCRIPTION
I would like to allow some way of supporting a TLS connection, specifying the certificates. This is a draft PR meant for discussion

Edit:

As it is about a RedisWrapper this solution is probably better:

```python
    def __init__(self, db_uri, collection, ttl=None, options={}):
        if not _has_redis:
            raise ImportError("redis module is required but it is not available")
        self._db = Redis.from_url(db_uri, decode_responses=True)
        self._db = Redis.from_url(db_uri, decode_responses=True, **options)
        ...
```