### PR TITLE
Add support for stateless code flow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     description='OpenID Connect Provider (OP) library in Python.',
     install_requires=[
         'oic >= 1.2.1',
+        'pycryptodomex',
     ],
     extras_require={
         'mongo': 'pymongo',

--- a/src/pyop/crypto.py
+++ b/src/pyop/crypto.py
@@ -1,0 +1,74 @@
+import base64
+import hashlib
+
+from Cryptodome import Random
+from Cryptodome.Cipher import AES
+
+
+class _AESCipher(object):
+    """
+    This class will perform AES encryption/decryption with a keylength of 256.
+
+    @see: http://stackoverflow.com/questions/12524994/encrypt-decrypt-using-pycrypto-aes-256
+    """
+
+    def __init__(self, key):
+        """
+        Constructor
+
+        :type key: str
+
+        :param key: The key used for encryption and decryption. The longer key the better.
+        """
+        self.bs = 32
+        self.key = hashlib.sha256(key.encode()).digest()
+
+    def encrypt(self, raw):
+        """
+        Encryptes the parameter raw.
+
+        :type raw: bytes
+        :rtype: str
+
+        :param: bytes to be encrypted.
+
+        :return: A base 64 encoded string.
+        """
+        raw = self._pad(raw)
+        iv = Random.new().read(AES.block_size)
+        cipher = AES.new(self.key, AES.MODE_CBC, iv)
+        return base64.urlsafe_b64encode(iv + cipher.encrypt(raw))
+
+    def decrypt(self, enc):
+        """
+        Decryptes the parameter enc.
+
+        :type enc: bytes
+        :rtype: bytes
+
+        :param: The value to be decrypted.
+        :return: The decrypted value.
+        """
+        enc = base64.urlsafe_b64decode(enc)
+        iv = enc[:AES.block_size]
+        cipher = AES.new(self.key, AES.MODE_CBC, iv)
+        return self._unpad(cipher.decrypt(enc[AES.block_size:]))
+
+    def _pad(self, b):
+        """
+        Will padd the param to be of the correct length for the encryption alg.
+
+        :type b: bytes
+        :rtype: bytes
+        """
+        return b + (self.bs - len(b) % self.bs) * chr(self.bs - len(b) % self.bs).encode("UTF-8")
+
+    @staticmethod
+    def _unpad(b):
+        """
+        Removes the padding performed by the method _pad.
+
+        :type b: bytes
+        :rtype: bytes
+        """
+        return b[:-ord(b[len(b) - 1:])]

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -79,11 +79,7 @@ class Provider(object):
         self.configuration_information.verify()
 
         self.authz_state = authz_state
-
-        if self.authz_state and self.authz_state.stateless:
-            self.stateless = True
-        else:
-            self.stateless = False
+        self.stateless = self.authz_state and self.authz_state.stateless
 
         self.clients = clients
         self.userinfo = userinfo
@@ -611,7 +607,7 @@ class Provider(object):
     def logout_user(self, subject_identifier=None, end_session_request=None):
         # type: (Optional[str], Optional[oic.oic.message.EndSessionRequest]) -> None
         if self.stateless:
-            raise OAuthError("logout user isn't supported with stateless provider", "invalid_request")
+            raise OAuthError("Logout is not supported with stateless storage provider", "invalid_request")
         if not end_session_request:
             end_session_request = EndSessionRequest()
         if 'id_token_hint' in end_session_request:

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -31,6 +31,7 @@ from .exceptions import AuthorizationError
 from .exceptions import InvalidAccessToken
 from .exceptions import InvalidTokenRequest
 from .exceptions import InvalidAuthorizationCode
+from .exceptions import OAuthError
 from .request_validator import authorization_request_verify
 from .request_validator import client_id_is_known
 from .request_validator import client_preferences_match_provider_capabilities
@@ -78,6 +79,12 @@ class Provider(object):
         self.configuration_information.verify()
 
         self.authz_state = authz_state
+
+        if self.authz_state and self.authz_state.stateless:
+            self.stateless = True
+        else:
+            self.stateless = False
+
         self.clients = clients
         self.userinfo = userinfo
         self.id_token_lifetime = id_token_lifetime
@@ -131,11 +138,12 @@ class Provider(object):
         logger.debug('parsed authentication_request: %s', auth_req)
         return auth_req
 
-    def authorize(self, authentication_request,  # type: AuthorizationRequest
-                  user_id,  # type: str
-                  extra_id_token_claims=None
-                  # type: Optional[Union[Mapping[str, Union[str, List[str]]], Callable[[str, str], Mapping[str, Union[str, List[str]]]]]
-                  ):
+    def authorize(
+        self,
+        authentication_request,  # type: AuthorizationRequest
+        user_id,  # type: str
+        extra_id_token_claims=None,  # type: Optional[Union[Mapping[str, Union[str, List[str]]], Callable[[str, str], Mapping[str, Union[str, List[str]]]]]
+    ):
         # type: (...) -> oic.oic.message.AuthorizationResponse
         """
         Creates an Authentication Response for the specified authentication request and local identifier of the
@@ -146,29 +154,42 @@ class Provider(object):
             self.authz_state.subject_identifiers[user_id] = {'public': custom_sub}
             sub = custom_sub
         else:
-            sub = self._create_subject_identifier(user_id, authentication_request['client_id'],
-                                                  authentication_request['redirect_uri'])
+            sub = self._create_subject_identifier(
+                user_id,
+                authentication_request['client_id'],
+                authentication_request['redirect_uri'],
+            )
 
         self._check_subject_identifier_matches_requested(authentication_request, sub)
+
+        if extra_id_token_claims is None:
+            extra_id_token_claims = {}
+        elif callable(extra_id_token_claims):
+            extra_id_token_claims = extra_id_token_claims(
+                user_id, authentication_request['client_id']
+            )
+
         response = AuthorizationResponse()
 
         authz_code = None
         if 'code' in authentication_request['response_type']:
-            authz_code = self.authz_state.create_authorization_code(authentication_request, sub)
+            authz_code = self.authz_state.create_authorization_code(
+                authentication_request,
+                sub,
+                user_info=self.userinfo[user_id],
+                extra_id_token_claims=extra_id_token_claims,
+            )
             response['code'] = authz_code
 
         access_token_value = None
         if 'token' in authentication_request['response_type']:
-            access_token = self.authz_state.create_access_token(authentication_request, sub)
+            access_token = self.authz_state.create_access_token(
+                authentication_request, sub, user_info=self.userinfo[user_id]
+            )
             access_token_value = access_token.value
             self._add_access_token_to_response(response, access_token)
 
         if 'id_token' in authentication_request['response_type']:
-            if extra_id_token_claims is None:
-                extra_id_token_claims = {}
-            elif callable(extra_id_token_claims):
-                extra_id_token_claims = extra_id_token_claims(user_id, authentication_request['client_id'])
-
             requested_claims = self._get_requested_claims_in(authentication_request, 'id_token')
             if len(authentication_request['response_type']) == 1:
                 # only id token is issued -> no way of doing userinfo request, so include all claims in ID Token,
@@ -180,12 +201,22 @@ class Provider(object):
                 )
 
             user_claims = self.userinfo.get_claims_for(user_id, requested_claims)
-            response['id_token'] = self._create_signed_id_token(authentication_request['client_id'], sub,
-                                                                user_claims,
-                                                                authentication_request.get('nonce'),
-                                                                authz_code, access_token_value, extra_id_token_claims)
-            logger.debug('issued id_token=%s from requested_claims=%s userinfo=%s extra_claims=%s',
-                         response['id_token'], requested_claims, user_claims, extra_id_token_claims)
+            response['id_token'] = self._create_signed_id_token(
+                authentication_request['client_id'],
+                sub,
+                user_claims,
+                authentication_request.get('nonce'),
+                authz_code,
+                access_token_value,
+                extra_id_token_claims,
+            )
+            logger.debug(
+                'issued id_token=%s from requested_claims=%s userinfo=%s extra_claims=%s',
+                response['id_token'],
+                requested_claims,
+                user_claims,
+                extra_id_token_claims,
+            )
 
         if 'state' in authentication_request:
             response['state'] = authentication_request['state']
@@ -329,7 +360,7 @@ class Provider(object):
         raise InvalidTokenRequest('grant_type \'{}\' unknown'.format(token_request['grant_type']), token_request,
                                   oauth_error='unsupported_grant_type')
 
-    def _PKCE_verify(self, 
+    def _PKCE_verify(self,
                      token_request, # type: AccessTokenRequest
                      authentication_request # type: AuthorizationRequest
                     ):
@@ -347,15 +378,15 @@ class Provider(object):
             return False
 
         if not 'code_challenge_method' in authentication_request:
-            raise InvalidTokenRequest("A code_challenge and code_verifier have been supplied" 
+            raise InvalidTokenRequest("A code_challenge and code_verifier have been supplied"
                                       "but missing code_challenge_method in authentication_request", token_request)
 
-        # OIC Provider extension returns either a boolean or Response object containing an error. To support 
+        # OIC Provider extension returns either a boolean or Response object containing an error. To support
         # stricter typing guidelines, return if True. Error handling support should be in encapsulating function.
-        return OICProviderExtensions.verify_code_challenge(token_request['code_verifier'], 
+        return OICProviderExtensions.verify_code_challenge(token_request['code_verifier'],
                                                            authentication_request['code_challenge'], authentication_request['code_challenge_method']) == True
 
-    def _verify_code_exchange_req(self, 
+    def _verify_code_exchange_req(self,
                                   token_request, # type: AccessTokenRequest
                                   authentication_request # type: AuthorizationRequest
                                   ):
@@ -367,7 +398,7 @@ class Provider(object):
 
         :param token_request: The request asking for a token given a code, and optionally a code_verifier
         :param authentication_request: The authentication request belonging to the provided code.
-        :raises InvalidTokenRequest, InvalidAuthorizationCode: If request is invalid, throw a representing exception. 
+        :raises InvalidTokenRequest, InvalidAuthorizationCode: If request is invalid, throw a representing exception.
         """
         if token_request['client_id'] != authentication_request['client_id']:
             logger.info('Authorization code \'%s\' belonging to \'%s\' was used by \'%s\'',
@@ -407,7 +438,8 @@ class Provider(object):
         self._verify_code_exchange_req(token_request, authentication_request)
 
         sub = self.authz_state.get_subject_identifier_for_code(token_request['code'])
-        user_id = self.authz_state.get_user_id_for_subject_identifier(sub)
+        if not self.stateless:
+            user_id = self.authz_state.get_user_id_for_subject_identifier(sub)
 
         response = AccessTokenResponse()
 
@@ -420,9 +452,19 @@ class Provider(object):
         if extra_id_token_claims is None:
             extra_id_token_claims = {}
         elif callable(extra_id_token_claims):
-            extra_id_token_claims = extra_id_token_claims(user_id, authentication_request['client_id'])
+            if self.stateless:
+                extra_id_token_claims = extra_id_token_claims(sub, authentication_request['client_id'])
+            else:
+                extra_id_token_claims = extra_id_token_claims(user_id, authentication_request['client_id'])
+        if self.stateless:
+            extra_id_token_claims_in_code = self.authz_state.get_extra_io_token_claims_for_code(token_request['code'])
+            extra_id_token_claims.update(extra_id_token_claims_in_code)
         requested_claims = self._get_requested_claims_in(authentication_request, 'id_token')
-        user_claims = self.userinfo.get_claims_for(user_id, requested_claims)
+        if self.stateless:
+            user_info = self.authz_state.get_user_info_for_code(token_request['code'])
+            user_claims = self.userinfo.get_claims_for(None, requested_claims, user_info)
+        else:
+            user_claims = self.userinfo.get_claims_for(user_id, requested_claims)
         response['id_token'] = self._create_signed_id_token(authentication_request['client_id'], sub,
                                                             user_claims,
                                                             authentication_request.get('nonce'),
@@ -487,12 +529,19 @@ class Provider(object):
         if not introspection['active']:
             raise InvalidAccessToken('The access token has expired')
         scopes = introspection['scope'].split()
-        user_id = self.authz_state.get_user_id_for_subject_identifier(introspection['sub'])
+
+        if not self.stateless:
+            user_id = self.authz_state.get_user_id_for_subject_identifier(introspection['sub'])
 
         requested_claims = scope2claims(scopes, extra_scope_dict=self.extra_scopes)
         authentication_request = self.authz_state.get_authorization_request_for_access_token(bearer_token)
         requested_claims.update(self._get_requested_claims_in(authentication_request, 'userinfo'))
-        user_claims = self.userinfo.get_claims_for(user_id, requested_claims)
+
+        if self.stateless:
+            user_info = self.authz_state.get_user_info_for_access_token(bearer_token)
+            user_claims = self.userinfo.get_claims_for(None, requested_claims, user_info)
+        else:
+            user_claims = self.userinfo.get_claims_for(user_id, requested_claims)
 
         user_claims.setdefault('sub', introspection['sub'])
         response = OpenIDSchema(**user_claims)
@@ -561,6 +610,8 @@ class Provider(object):
 
     def logout_user(self, subject_identifier=None, end_session_request=None):
         # type: (Optional[str], Optional[oic.oic.message.EndSessionRequest]) -> None
+        if self.stateless:
+            raise OAuthError("logout user isn't supported with stateless provider", "invalid_request")
         if not end_session_request:
             end_session_request = EndSessionRequest()
         if 'id_token_hint' in end_session_request:

--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from abc import ABC, abstractmethod
-from Cryptodome import Random
-from Cryptodome.Cipher import AES
 import copy
 import json
-import base64
-import hashlib
 import logging
 from datetime import datetime
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
+from urllib.parse import parse_qs
+
+from .crypto import _AESCipher
+
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +241,7 @@ class StatelessWrapper(StorageBase):
         if not alg or alg.lower() == "aes256":
             self.cipher = _AESCipher(encryption_key)
         else:
-            return ValueError(f"Invalid encryption algorithm: {alg}")
+            raise ValueError(f"Invalid encryption algorithm: {alg}")
 
     def __setitem__(self, key, value):
         pass
@@ -280,75 +280,6 @@ class StatelessWrapper(StorageBase):
             else:
                 logger.warning("Value '%s' is invalid for %s", value, self.collection)
         return unpacked_val
-
-
-class _AESCipher(object):
-    """
-    This class will perform AES encryption/decryption with a keylength of 256.
-
-    @see: http://stackoverflow.com/questions/12524994/encrypt-decrypt-using-pycrypto-aes-256
-    """
-
-    def __init__(self, key):
-        """
-        Constructor
-
-        :type key: str
-
-        :param key: The key used for encryption and decryption. The longer key the better.
-        """
-        self.bs = 32
-        self.key = hashlib.sha256(key.encode()).digest()
-
-    def encrypt(self, raw):
-        """
-        Encryptes the parameter raw.
-
-        :type raw: bytes
-        :rtype: str
-
-        :param: bytes to be encrypted.
-
-        :return: A base 64 encoded string.
-        """
-        raw = self._pad(raw)
-        iv = Random.new().read(AES.block_size)
-        cipher = AES.new(self.key, AES.MODE_CBC, iv)
-        return base64.urlsafe_b64encode(iv + cipher.encrypt(raw))
-
-    def decrypt(self, enc):
-        """
-        Decryptes the parameter enc.
-
-        :type enc: bytes
-        :rtype: bytes
-
-        :param: The value to be decrypted.
-        :return: The decrypted value.
-        """
-        enc = base64.urlsafe_b64decode(enc)
-        iv = enc[:AES.block_size]
-        cipher = AES.new(self.key, AES.MODE_CBC, iv)
-        return self._unpad(cipher.decrypt(enc[AES.block_size:]))
-
-    def _pad(self, b):
-        """
-        Will padd the param to be of the correct length for the encryption alg.
-
-        :type b: bytes
-        :rtype: bytes
-        """
-        return b + (self.bs - len(b) % self.bs) * chr(self.bs - len(b) % self.bs).encode("UTF-8")
-
-    @staticmethod
-    def _unpad(b):
-        """
-        Removes the padding performed by the method _pad.
-
-        :type b: bytes
-        :rtype: bytes
-        """
-        return b[:-ord(b[len(b) - 1:])]
 
 
 class MongoDB(object):

--- a/src/pyop/userinfo.py
+++ b/src/pyop/userinfo.py
@@ -18,16 +18,19 @@ class Userinfo(object):
     def __contains__(self, item):
         return item in self._db
 
-    def get_claims_for(self, user_id, requested_claims):
+    def get_claims_for(self, user_id, requested_claims, userinfo=None):
         # type: (str, Mapping[str, Optional[Mapping[str, Union[str, List[str]]]]) -> Dict[str, Union[str, List[str]]]
         """
         Filter the userinfo based on which claims where requested.
         :param user_id: user identifier
         :param requested_claims: see <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">
             "OpenID Connect Core 1.0", Section 5.5</a> for structure
+        :param userinfo: if user_info is specified the claims will be filtered from the user_info directly instead
+        first querying the storage against the user_id
         :return: All requested claims available from the userinfo.
         """
 
-        userinfo = self._db[user_id]
+        if not userinfo:
+            userinfo = self._db[user_id]
         claims = {claim: userinfo[claim] for claim in requested_claims if claim in userinfo}
         return claims

--- a/tests/pyop/test_stateless_provider.py
+++ b/tests/pyop/test_stateless_provider.py
@@ -1,0 +1,708 @@
+import datetime as dt
+import json
+import time
+from collections import Counter
+from unittest.mock import Mock, patch
+from urllib.parse import urlencode
+
+import pytest
+from Cryptodome.PublicKey import RSA
+from jwkest import jws
+from jwkest.jwk import RSAKey
+from oic import rndstr
+from oic.oauth2.message import MissingRequiredValue, MissingRequiredAttribute
+from oic.oic import PREFERENCE2PROVIDER
+from oic.oic.message import IdToken, ClaimsRequest, Claims, EndSessionRequest, EndSessionResponse
+
+import pyop.storage
+from pyop.message import AuthorizationRequest
+from pyop.access_token import BearerTokenError
+from pyop.authz_state import AuthorizationState
+from pyop.client_authentication import InvalidClientAuthentication
+from pyop.exceptions import InvalidAuthenticationRequest, AuthorizationError, InvalidTokenRequest, \
+    InvalidClientRegistrationRequest, InvalidAccessToken, InvalidAuthorizationCode, InvalidSubjectIdentifier, OAuthError
+from pyop.provider import Provider, redirect_uri_is_in_registered_redirect_uris, \
+    response_type_is_in_registered_response_types
+from pyop.subject_identifier import HashBasedSubjectIdentifierFactory
+from pyop.userinfo import Userinfo
+
+TEST_CLIENT_ID = 'client1'
+TEST_CLIENT_SECRET = 'secret'
+INVALID_TEST_CLIENT_ID = 'invalid_client'
+INVALID_TEST_CLIENT_SECRET = 'invalid_secret'
+TEST_REDIRECT_URI = 'https://client.example.com'
+ISSUER = 'https://provider.example.com'
+TEST_USER_ID = 'user1'
+
+
+def get_test_user_data():
+    return {
+        'name': 'The T. Tester',
+        'family_name': 'Tester',
+        'given_name': 'The',
+        'middle_name': 'Theodore',
+        'nickname': 'testster',
+        'email': 'testster@example.com'
+    }
+
+
+MOCK_TIME = Mock(return_value=time.mktime(dt.datetime(2016, 6, 21).timetuple()))
+
+
+def rsa_key():
+    return RSAKey(key=RSA.generate(1024), use="sig", alg="RS256", kid=rndstr(4))
+
+
+def provide_configuration():
+    conf = {
+        'issuer': ISSUER,
+        'jwks_uri': '/jwks',
+        'authorization_endpoint': '/authorization',
+        'token_endpoint': '/token'
+    }
+    return conf
+
+
+def assert_id_token_base_claims(jws, verification_key, provider, auth_req):
+    id_token = IdToken().from_jwt(jws, key=[verification_key])
+    assert id_token['nonce'] == auth_req['nonce']
+    assert id_token['iss'] == ISSUER
+    assert provider.authz_state.get_user_id_for_subject_identifier(id_token['sub']) == TEST_USER_ID
+    assert id_token['iat'] == MOCK_TIME.return_value
+    assert id_token['exp'] == id_token['iat'] + provider.id_token_lifetime
+    assert TEST_CLIENT_ID in id_token['aud']
+
+    return id_token
+
+
+@pytest.fixture
+def auth_req_args(request):
+    request.instance.authn_request_args = {
+        'scope': 'openid',
+        'response_type': 'code',
+        'client_id': TEST_CLIENT_ID,
+        'redirect_uri': TEST_REDIRECT_URI,
+        'state': 'state',
+        'nonce': 'nonce'
+    }
+
+
+@pytest.fixture
+def inject_stateless_provider(request):
+    clients = {
+        TEST_CLIENT_ID: {
+            'subject_type': 'pairwise',
+            'redirect_uris': [TEST_REDIRECT_URI],
+            'response_types': ['code'],
+            'client_secret': TEST_CLIENT_SECRET,
+            'token_endpoint_auth_method': 'client_secret_post',
+            'post_logout_redirect_uris': ['https://client.example.com/post_logout']
+        },
+        INVALID_TEST_CLIENT_ID: {
+            'subject_type': 'pairwise',
+            'redirect_uris': 'http://invalid.redirect.loc',
+            'response_types': ['code'],
+            'client_secret': INVALID_TEST_CLIENT_SECRET,
+            'token_endpoint_auth_method': 'client_secret_post',
+            'post_logout_redirect_uris': ['https://client.example.com/post_logout']
+        }
+    }
+
+    userinfo = Userinfo({
+        TEST_USER_ID: get_test_user_data()
+    })
+
+    stateless_storage = pyop.storage.StatelessWrapper("pyop", "abc123")
+
+    auth_state = AuthorizationState(HashBasedSubjectIdentifierFactory('salt'), refresh_token_lifetime=3600,
+                                    authorization_code_db=stateless_storage,
+                                    access_token_db=stateless_storage,
+                                    refresh_token_db=stateless_storage)
+
+    request.instance.provider = Provider(rsa_key(), provide_configuration(),
+                                         auth_state,
+                                         clients, userinfo)
+
+
+@pytest.mark.usefixtures('inject_stateless_provider', 'auth_req_args')
+class TestProviderParseAuthenticationRequest(object):
+    def test_parse_authentication_request(self):
+        nonce = 'nonce'
+        self.authn_request_args['nonce'] = nonce
+
+        received_request = self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+        assert received_request.to_dict() == self.authn_request_args
+
+    def test_reject_request_with_missing_required_parameter(self):
+        del self.authn_request_args['redirect_uri']
+
+        with pytest.raises(InvalidAuthenticationRequest) as exc:
+            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+        assert isinstance(exc.value.__cause__, MissingRequiredAttribute)
+
+    def test_reject_request_with_scope_without_openid(self):
+        self.authn_request_args['scope'] = 'foobar'  # does not contain 'openid'
+
+        with pytest.raises(InvalidAuthenticationRequest) as exc:
+            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+        assert isinstance(exc.value.__cause__, MissingRequiredValue)
+
+    def test_custom_validation_hook_reject(self):
+        class TestException(Exception):
+            pass
+
+        def fail_all_requests(auth_req):
+            raise InvalidAuthenticationRequest("Test exception", auth_req) from TestException()
+
+        self.provider.authentication_request_validators.append(fail_all_requests)
+        with pytest.raises(InvalidAuthenticationRequest) as exc:
+            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+
+        assert isinstance(exc.value.__cause__, TestException)
+
+    def test_redirect_uri_not_matching_registered_redirect_uris(self):
+        self.authn_request_args['redirect_uri'] = 'https://something.example.com'
+        with pytest.raises(InvalidAuthenticationRequest):
+            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+
+    def test_response_type_not_matching_registered_response_types(self):
+        self.authn_request_args['response_type'] = 'id_token'
+        with pytest.raises(InvalidAuthenticationRequest):
+            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+
+    def test_unknown_client_id(self):
+        self.authn_request_args['client_id'] = 'unknown'
+        with pytest.raises(InvalidAuthenticationRequest):
+            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+
+    def test_include_userinfo_claims_request_with_response_type_id_token(self):
+        self.authn_request_args['claims'] = ClaimsRequest(userinfo=Claims(nickname=None)).to_json()
+        self.provider.clients[TEST_CLIENT_ID]['response_types'] = ['id_token']
+        self.authn_request_args['response_type'] = 'id_token'
+        with pytest.raises(InvalidAuthenticationRequest):
+            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
+
+
+@pytest.mark.usefixtures('auth_req_args')
+class TestAuthenticationRequestValidators(object):
+    @pytest.fixture
+    def provider_mock(self):
+        provider = Mock()
+        provider.clients = Mock()
+        provider.clients.__getitem__ = Mock(return_value={})
+        return provider
+
+    def test_redirect_uri_is_in_registered_redirect_uris_with_no_redirect_uris(self, provider_mock):
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        with pytest.raises(InvalidAuthenticationRequest):
+            redirect_uri_is_in_registered_redirect_uris(provider_mock, auth_req)
+
+    def test_response_type_is_in_registered_response_types_with_no_response_types(self, provider_mock):
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        with pytest.raises(InvalidAuthenticationRequest):
+            response_type_is_in_registered_response_types(provider_mock, auth_req)
+
+
+@pytest.mark.usefixtures('inject_stateless_provider', 'auth_req_args')
+class TestProviderAuthorize(object):
+    def test_authorize(self):
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        resp = self.provider.authorize(auth_req, TEST_USER_ID)
+        assert resp['code'] in self.provider.authz_state.authorization_codes
+        assert resp['state'] == self.authn_request_args['state']
+
+    def test_authorize_with_custom_sub(self, monkeypatch):
+        sub = 'test_sub1'
+        monkeypatch.setitem(self.provider.userinfo._db[TEST_USER_ID], 'sub', sub)
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        resp = self.provider.authorize(auth_req, TEST_USER_ID)
+        assert resp['code'] in self.provider.authz_state.authorization_codes
+        assert resp['state'] == self.authn_request_args['state']
+        assert self.provider.authz_state.authorization_codes[resp['code']]['sub'] == sub
+
+    @patch('time.time', MOCK_TIME)
+    @pytest.mark.parametrize('extra_claims', [
+        {'foo': 'bar'},
+        lambda user_id, client_id: {'foo': 'bar'}
+    ])
+    def test_authorize_with_extra_id_token_claims(self, extra_claims):
+        self.authn_request_args['response_type'] = ['id_token']  # make sure ID Token is produced
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        resp = self.provider.authorize(auth_req, TEST_USER_ID, extra_claims)
+        id_token = assert_id_token_base_claims(resp['id_token'], self.provider.signing_key, self.provider, auth_req)
+        assert id_token['foo'] == 'bar'
+
+    def test_authorize_include_user_claims_from_scope_in_id_token_if_no_userinfo_req_can_be_made(self):
+        self.authn_request_args['response_type'] = 'id_token'
+        self.authn_request_args['scope'] = 'openid profile'
+        self.authn_request_args['claims'] = ClaimsRequest(id_token=Claims(email={'essential': True}))
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        resp = self.provider.authorize(auth_req, TEST_USER_ID)
+
+        id_token = IdToken().from_jwt(resp['id_token'], key=[self.provider.signing_key])
+        # verify all claims are part of the ID Token
+        assert all(id_token[claim] == value for claim, value in get_test_user_data().items())
+
+    @patch('time.time', MOCK_TIME)
+    def test_authorize_includes_requested_id_token_claims_even_if_token_request_can_be_made(self):
+        self.authn_request_args['response_type'] = ['id_token', 'token']
+        self.authn_request_args['claims'] = ClaimsRequest(id_token=Claims(email=None))
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        resp = self.provider.authorize(auth_req, TEST_USER_ID)
+        id_token = assert_id_token_base_claims(resp['id_token'], self.provider.signing_key, self.provider, auth_req)
+        assert id_token['email'] == get_test_user_data()['email']
+
+    @patch('time.time', MOCK_TIME)
+    def test_hybrid_flow(self):
+        self.authn_request_args['response_type'] = 'code id_token token'
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        resp = self.provider.authorize(auth_req, TEST_USER_ID, extra_id_token_claims={'foo': 'bar'})
+
+        assert resp['state'] == self.authn_request_args['state']
+        assert resp['code'] in self.provider.authz_state.authorization_codes
+
+        assert resp['access_token'] in self.provider.authz_state.access_tokens
+        assert resp['expires_in'] == self.provider.authz_state.access_token_lifetime
+        assert resp['token_type'] == 'Bearer'
+
+        id_token = IdToken().from_jwt(resp['id_token'], key=[self.provider.signing_key])
+        assert_id_token_base_claims(resp['id_token'], self.provider.signing_key, self.provider, self.authn_request_args)
+        assert id_token["c_hash"] == jws.left_hash(resp['code'].encode('utf-8'), 'HS256')
+        assert id_token["at_hash"] == jws.left_hash(resp['access_token'].encode('utf-8'), 'HS256')
+        assert id_token['foo'] == 'bar'
+
+    @pytest.mark.parametrize('claims_location', [
+        'id_token',
+        'userinfo'
+    ])
+    def test_with_requested_sub_not_matching(self, claims_location):
+        self.authn_request_args['claims'] = ClaimsRequest(**{claims_location: Claims(sub={'value': 'nomatch'})})
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        with pytest.raises(AuthorizationError):
+            self.provider.authorize(auth_req, TEST_USER_ID)
+
+    def test_with_multiple_requested_sub(self):
+        self.authn_request_args['claims'] = ClaimsRequest(userinfo=Claims(sub={'value': 'nomatch1'}),
+                                                          id_token=Claims(sub={'value': 'nomatch2'}))
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        with pytest.raises(AuthorizationError) as exc:
+            self.provider.authorize(auth_req, TEST_USER_ID)
+
+        assert 'different' in str(exc.value)
+
+
+@pytest.mark.usefixtures('inject_stateless_provider', 'auth_req_args')
+class TestProviderHandleTokenRequest(object):
+    def create_authz_code(self, extra_auth_req_params=None):
+        sub = self.provider.authz_state.get_subject_identifier('pairwise', TEST_USER_ID, 'client1.example.com')
+
+        if extra_auth_req_params:
+            self.authn_request_args.update(extra_auth_req_params)
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        return self.provider.authz_state.create_authorization_code(auth_req, sub, user_info=get_test_user_data())
+
+    def create_refresh_token(self):
+        sub = self.provider.authz_state.get_subject_identifier('pairwise', TEST_USER_ID, 'client1.example.com')
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        access_token = self.provider.authz_state.create_access_token(auth_req, sub)
+        return self.provider.authz_state.create_refresh_token(access_token.value)
+
+    @pytest.fixture(autouse=True)
+    def create_token_request_args(self):
+        self.authorization_code_exchange_request_args = {
+            'grant_type': 'authorization_code',
+            'code': None,
+            'redirect_uri': 'https://client.example.com',
+            'client_id': TEST_CLIENT_ID,
+            'client_secret': TEST_CLIENT_SECRET
+        }
+
+        self.refresh_token_request_args = {
+            'grant_type': 'refresh_token',
+            'refresh_token': None,
+            'scope': 'openid',
+            'client_id': TEST_CLIENT_ID,
+            'client_secret': TEST_CLIENT_SECRET
+        }
+
+    @patch('time.time', MOCK_TIME)
+    def test_code_exchange_request(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        response = self.provider._do_code_exchange(self.authorization_code_exchange_request_args, None)
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
+                                    self.authn_request_args)
+
+    @patch('time.time', MOCK_TIME)
+    def test_pkce_code_exchange_request(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
+            {
+                "code_challenge": "_1f8tFjAtu6D1Df-GOyDPoMjCJdEvaSWsnqR6SLpzsw",
+                "code_challenge_method": "S256"
+            }
+        )
+        self.authorization_code_exchange_request_args['code_verifier'] = "SoOEDN-mZKNhw7Mc52VXxyiqTvFB3mod36MwPru253c"
+        response = self.provider._do_code_exchange(self.authorization_code_exchange_request_args, None)
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
+                                    self.authn_request_args)
+
+    @patch('time.time', MOCK_TIME)
+    def test_code_exchange_request_with_claims_requested_in_id_token(self):
+        claims_req = {'claims': ClaimsRequest(id_token=Claims(email=None))}
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(extra_auth_req_params=claims_req)
+        response = self.provider._do_code_exchange(self.authorization_code_exchange_request_args, None)
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        id_token = assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
+                                               self.authn_request_args)
+        assert id_token['email'] == self.provider.userinfo[TEST_USER_ID]['email']
+
+    @patch('time.time', MOCK_TIME)
+    @pytest.mark.parametrize('extra_claims', [
+        {'foo': 'bar'},
+        lambda user_id, client_id: {'foo': 'bar'}
+    ])
+    def test_handle_token_request_with_extra_id_token_claims(self, extra_claims):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        response = self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args),
+                                                      extra_id_token_claims=extra_claims)
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        id_token = assert_id_token_base_claims(response['id_token'], self.provider.signing_key, self.provider,
+                                               self.authn_request_args)
+        assert id_token['foo'] == 'bar'
+
+    def test_handle_token_request_reject_invalid_client_authentication(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        self.authorization_code_exchange_request_args['client_secret'] = 'invalid'
+        with pytest.raises(InvalidClientAuthentication):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args),
+                                               extra_id_token_claims={'foo': 'bar'})
+
+    def test_handle_token_request_reject_code_not_issued_to_client(self):
+        self.authorization_code_exchange_request_args['client_id'] = INVALID_TEST_CLIENT_ID
+        self.authorization_code_exchange_request_args['client_secret'] = INVALID_TEST_CLIENT_SECRET
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        with pytest.raises(InvalidAuthorizationCode):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_handle_token_request_reject_invalid_redirect_uri_in_exchange_request(self):
+        self.authorization_code_exchange_request_args['redirect_uri'] = 'https://invalid.com'
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        with pytest.raises(InvalidTokenRequest):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_handle_token_request_reject_invalid_grant_type(self):
+        self.authorization_code_exchange_request_args['grant_type'] = 'invalid'
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        with pytest.raises(InvalidTokenRequest):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_handle_token_request_reject_missing_grant_type(self):
+        del self.authorization_code_exchange_request_args['grant_type']
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code()
+        with pytest.raises(InvalidTokenRequest):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_handle_token_request_reject_invalid_code_verifier(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
+            {
+                "code_challenge": "_1f8tFjAtu6D1Df-GOyDPoMjCJdEvaSWsnqR6SLpzsw=",
+                "code_challenge_method": "S256"
+            }
+        )
+        self.authorization_code_exchange_request_args['code_verifier'] = "ThiS Cer_tainly Ain't Valid"
+        with pytest.raises(InvalidTokenRequest):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_handle_token_request_reject_unsynced_requests(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
+            {
+                "code_challenge": "_1f8tFjAtu6D1Df-GOyDPoMjCJdEvaSWsnqR6SLpzsw=",
+                "code_challenge_method": "S256"
+            }
+        )
+        with pytest.raises(InvalidTokenRequest):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_handle_token_request_reject_missing_code_challenge_method(self):
+        self.authorization_code_exchange_request_args['code'] = self.create_authz_code(
+            {
+                "code_challenge": "_1f8tFjAtu6D1Df-GOyDPoMjCJdEvaSWsnqR6SLpzsw=",
+            }
+        )
+        with pytest.raises(InvalidTokenRequest):
+            self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
+
+    def test_refresh_request(self):
+        self.provider.authz_state = AuthorizationState(HashBasedSubjectIdentifierFactory('salt'),
+                                                       refresh_token_lifetime=600)
+        self.refresh_token_request_args['refresh_token'] = self.create_refresh_token()
+        response = self.provider.handle_token_request(urlencode(self.refresh_token_request_args))
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        assert 'refresh_token' not in response
+
+    def test_refresh_request_with_refresh_token_close_to_expiry_issues_new_refresh_token(self):
+        self.provider.authz_state = AuthorizationState(HashBasedSubjectIdentifierFactory('salt'),
+                                                       refresh_token_lifetime=10,
+                                                       refresh_token_threshold=2)
+        self.refresh_token_request_args['refresh_token'] = self.create_refresh_token()
+
+        close_to_expiration = int(time.time()) + self.provider.authz_state.refresh_token_lifetime - 1
+        with patch('time.time', Mock(return_value=close_to_expiration)):
+            response = self.provider.handle_token_request(urlencode(self.refresh_token_request_args))
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        assert response['refresh_token'] in self.provider.authz_state.refresh_tokens
+
+    def test_refresh_request_without_scope_parameter_defaults_to_scope_from_authentication_request(self):
+        self.provider.authz_state = AuthorizationState(HashBasedSubjectIdentifierFactory('salt'),
+                                                       refresh_token_lifetime=600)
+        self.refresh_token_request_args['refresh_token'] = self.create_refresh_token()
+        del self.refresh_token_request_args['scope']
+        response = self.provider.handle_token_request(urlencode(self.refresh_token_request_args))
+        assert response['access_token'] in self.provider.authz_state.access_tokens
+        assert self.provider.authz_state.access_tokens[response['access_token']]['scope'] == self.authn_request_args[
+            'scope']
+
+    @pytest.mark.parametrize('missing_parameter', [
+        'grant_type',
+        'code',
+        'redirect_uri'
+    ])
+    def test_code_exchange_request_with_missing_parameter(self, missing_parameter):
+        request_args = {
+            'grant_type': 'authorization_code',
+            'code': None,
+            'redirect_uri': TEST_REDIRECT_URI,
+        }
+        del request_args[missing_parameter]
+        with pytest.raises(InvalidTokenRequest):
+            self.provider._do_code_exchange(request_args)
+
+    @pytest.mark.parametrize('missing_parameter', [
+        'grant_type',
+        'refresh_token',
+    ])
+    def test_refresh_token_request_with_missing_parameter(self, missing_parameter):
+        request_args = {
+            'grant_type': 'refresh_token',
+            'refresh_token': None,
+        }
+        del request_args[missing_parameter]
+        with pytest.raises(InvalidTokenRequest):
+            self.provider._do_token_refresh(request_args)
+
+
+@pytest.mark.usefixtures('inject_stateless_provider', 'auth_req_args')
+class TestProviderHandleUserinfoRequest(object):
+    def create_access_token(self, extra_auth_req_params=None):
+        sub = self.provider.authz_state.get_subject_identifier('pairwise', TEST_USER_ID, 'client1.example.com')
+
+        if extra_auth_req_params:
+            self.authn_request_args.update(extra_auth_req_params)
+
+        auth_req = AuthorizationRequest().from_dict(self.authn_request_args)
+        access_token = self.provider.authz_state.create_access_token(auth_req, sub, user_info=get_test_user_data())
+        return access_token.value
+
+    def test_handle_userinfo(self):
+        claims_request = ClaimsRequest(userinfo=Claims(email=None))
+        access_token = self.create_access_token({'scope': 'openid profile', 'claims': claims_request})
+        response = self.provider.handle_userinfo_request(urlencode({'access_token': access_token}))
+
+        response_sub = response['sub']
+        del response['sub']
+        assert response.to_dict() == self.provider.userinfo[TEST_USER_ID]
+        assert self.provider.authz_state.get_user_id_for_subject_identifier(response_sub) == TEST_USER_ID
+
+    def test_handle_userinfo_with_custom_sub(self, monkeypatch):
+        sub = 'f0f49e5b3ca9ff385451397f73483472db16ec4441f34cf00ae29028460cb206'
+        claims_request = ClaimsRequest(userinfo=Claims(email=None))
+        access_token = self.create_access_token({'scope': 'openid profile', 'claims': claims_request})
+        response = self.provider.handle_userinfo_request(urlencode({'access_token': access_token}))
+
+        assert response['sub'] == sub
+
+    def test_handle_userinfo_rejects_request_missing_access_token(self):
+        with pytest.raises(BearerTokenError) as exc:
+            self.provider.handle_userinfo_request()
+
+    def test_handle_userinfo_rejects_invalid_access_token(self):
+        access_token = self.create_access_token()
+        access_token =  'making_access_token_dirty' + access_token
+        with pytest.raises(InvalidAccessToken):
+            self.provider.handle_userinfo_request(urlencode({'access_token': access_token}))
+
+
+@pytest.mark.usefixtures('inject_stateless_provider')
+class TestProviderHandleRegistrationRequest(object):
+    def test_handle_registration_request(self):
+        request = {'redirect_uris': ['https://client.example.com/redirect']}
+        response = self.provider.handle_client_registration_request(json.dumps(request))
+        assert 'client_id' in response
+        assert 'client_id_issued_at' in response
+        assert 'client_secret' in response
+        assert response['client_secret_expires_at'] == 0
+        assert all(k in response.items() for k in request.items())
+
+        assert response['client_id'] in self.provider.clients
+
+    def test_rejects_invalid_request(self):
+        request = {'application_type': 'web', 'client_name': 'test client'}  # missing 'redirect_uris'
+        with pytest.raises(InvalidClientRegistrationRequest):
+            self.provider.handle_client_registration_request(json.dumps(request))
+
+    @pytest.mark.parametrize('client_preference, provider_capability, client_value, provider_value', [
+        ('request_object_signing_alg', 'request_object_signing_alg_values_supported',
+         'HS256', ['none', 'RS256']),
+        ('request_object_encryption_alg', 'request_object_encryption_alg_values_supported',
+         'RSA-OAEP-256', ['RSA-OAEP', 'ECDH-ES']),
+        ('request_object_encryption_enc', 'request_object_encryption_enc_values_supported',
+         'A192CBC-HS384', ['A128CBC-HS256', 'A256CBC-HS512 ']),
+        ('userinfo_signed_response_alg', 'userinfo_signing_alg_values_supported',
+         'HS256', ['none', 'RS256']),
+        ('userinfo_encrypted_response_alg', 'userinfo_encryption_alg_values_supported',
+         'RSA-OAEP-256', ['RSA-OAEP', 'ECDH-ES']),
+        ('userinfo_encrypted_response_enc', 'userinfo_encryption_enc_values_supported',
+         'A192CBC-HS384', ['A128CBC-HS256', 'A256CBC-HS512 ']),
+        ('id_token_signed_response_alg', 'id_token_signing_alg_values_supported',
+         'HS256', ['none', 'RS256']),
+        ('id_token_encrypted_response_alg', 'id_token_encryption_alg_values_supported',
+         'RSA-OAEP-256', ['RSA-OAEP', 'ECDH-ES']),
+        ('id_token_encrypted_response_enc', 'id_token_encryption_enc_values_supported',
+         'A192CBC-HS384', ['A128CBC-HS256', 'A256CBC-HS512 ']),
+        ('default_acr_values', 'acr_values_supported',
+         ['1', '2'], ['3', '4']),
+        ('subject_type', 'subject_types_supported',
+         'public', ['pairwise']),
+        ('token_endpoint_auth_method', 'token_endpoint_auth_methods_supported',
+         'private_key_jwt', ['client_secret_post', 'client_secret_basic']),
+        ('token_endpoint_auth_signing_alg', 'token_endpoint_auth_signing_alg_values_supported',
+         'HS256', ['none', 'RS256']),
+        ('response_types', 'response_types_supported',
+         ['id_token token'], ['code', 'code token']),
+        ('grant_types', 'grant_types_supported',
+         'implicit', ['authorization_code'])
+    ])
+    def test_rejects_mismatching_request(self, client_preference, provider_capability, client_value, provider_value):
+        request = {'redirect_uris': ['https://client.example.com/redirect']}
+        provider_capabilities = provide_configuration()
+
+        if client_preference.startswith(('request_object_encryption', 'id_token_encrypted', 'userinfo_encrypted')):
+            # provide default value for the metadata params that come in pairs
+            param = client_preference[:-4]
+            alg_param = param + '_alg'
+            request[alg_param] = 'RSA-OAEP'
+            provider_capabilities[PREFERENCE2PROVIDER[alg_param]] = ['RSA-OAEP']
+            enc_param = param + '_enc'
+            request[enc_param] = 'A192CBC-HS256'
+            provider_capabilities[PREFERENCE2PROVIDER[enc_param]] = ['A192CBC-HS256']
+
+        request[client_preference] = client_value
+        provider_capabilities[provider_capability] = provider_value
+        provider = Provider(rsa_key(), provider_capabilities,
+                            AuthorizationState(HashBasedSubjectIdentifierFactory('salt')), {}, None)
+        with pytest.raises(InvalidClientRegistrationRequest):
+            provider.handle_client_registration_request(json.dumps(request))
+
+    @pytest.mark.parametrize('client_preference, provider_capability, client_value, provider_value', [
+        ('response_types', 'response_types_supported',
+         ['code id_token token', 'code', 'id_token', 'id_token token'],
+         ['code id_token token', 'id_token token']),
+        ('default_acr_values', 'acr_values_supported',
+         ['1', '2', '3'], ['2', '3', '4']),
+    ])
+    def test_matches_common_set_of_metadata_values(self, client_preference, provider_capability,
+                                                   client_value, provider_value):
+        provider_capabilities = provide_configuration()
+        provider_capabilities.update({provider_capability: provider_value})
+        provider = Provider(rsa_key(), provider_capabilities,
+                            AuthorizationState(HashBasedSubjectIdentifierFactory('salt')), {}, None)
+        request = {'redirect_uris': ['https://client.example.com/redirect'], client_preference: client_value}
+        response = provider.handle_client_registration_request(json.dumps(request))
+        expected_values = set(client_value).intersection(provider_value)
+        assert Counter(frozenset(v.split()) for v in response[client_preference]) == \
+               Counter(frozenset(v.split()) for v in expected_values)
+
+    def test_match_space_separated_response_type_without_order(self):
+        registration_request = {'redirect_uris': ['https://client.example.com/redirect'],
+                                'response_types': ['id_token token']}
+        # should not raise an exception
+        assert self.provider.handle_client_registration_request(json.dumps(registration_request))
+
+    def test_client_can_use_registered_space_separated_response_type_in_authentication_request(self):
+        response_type = 'id_token token'
+        registration_request = {'redirect_uris': ['https://client.example.com/redirect'],
+                                'response_types': [response_type]}
+        registration_response = self.provider.handle_client_registration_request(json.dumps(registration_request))
+
+        authentication_request = {'client_id': registration_response['client_id'],
+                                  'redirect_uri': 'https://client.example.com/redirect',
+                                  'scope': 'openid',
+                                  'nonce': 'nonce',
+                                  'response_type': response_type}
+        # should not raise an exception
+        assert self.provider.parse_authentication_request(urlencode(authentication_request))
+
+
+class TestProviderProviderConfiguration(object):
+    def test_provider_configuration(self):
+        config = provide_configuration()
+        config.update({'foo': 'bar', 'abc': 'xyz'})
+        provider = Provider(None, config, None, None, None)
+        provider_config = provider.provider_configuration
+        assert all(k in provider_config for k in config)
+
+
+class TestProviderJWKS(object):
+    def test_jwks(self):
+        provider = Provider(rsa_key(), provide_configuration(), None, None, None)
+        assert provider.jwks == {'keys': [provider.signing_key.serialize()]}
+
+
+@pytest.mark.usefixtures('inject_stateless_provider')
+class TestRPInitiatedLogout(object):
+    def test_logout_user_with_subject_identifier(self):
+        auth_req = AuthorizationRequest(response_type='code id_token token', scope='openid', client_id='client1',
+                                        redirect_uri='https://client.example.com/redirect')
+        auth_resp = self.provider.authorize(auth_req, 'user1')
+
+        id_token = IdToken().from_jwt(auth_resp['id_token'], key=[self.provider.signing_key])
+        with pytest.raises(OAuthError):
+            self.provider.logout_user(subject_identifier=id_token['sub'])
+
+    def test_logout_user_with_id_token_hint(self):
+        auth_req = AuthorizationRequest(response_type='code id_token token', scope='openid', client_id='client1',
+                                        redirect_uri='https://client.example.com/redirect')
+        auth_resp = self.provider.authorize(auth_req, 'user1')
+
+        with pytest.raises(OAuthError):
+            self.provider.logout_user(end_session_request=EndSessionRequest(id_token_hint=auth_resp['id_token']))
+
+    def test_logout_user_with_unknown_subject_identifier(self):
+        with pytest.raises(OAuthError):
+            self.provider.logout_user(subject_identifier='unknown')
+
+    def test_post_logout_redirect(self):
+        auth_req = AuthorizationRequest(response_type='code id_token token', scope='openid', client_id='client1',
+                                        redirect_uri='https://client.example.com/redirect')
+        auth_resp = self.provider.authorize(auth_req, 'user1')
+        end_session_request = EndSessionRequest(id_token_hint=auth_resp['id_token'],
+                                                post_logout_redirect_uri='https://client.example.com/post_logout',
+                                                state='state')
+        redirect_url = self.provider.do_post_logout_redirect(end_session_request)
+        assert redirect_url == EndSessionResponse(state='state').request('https://client.example.com/post_logout')
+
+    def test_post_logout_redirect_without_post_logout_redirect_uri(self):
+        assert self.provider.do_post_logout_redirect(EndSessionRequest()) is None
+
+    def test_post_logout_redirect_with_unknown_client_for_post_logout_redirect_uri(self):
+        end_session_request = EndSessionRequest(post_logout_redirect_uri='https://client.example.com/post_logout')
+        assert self.provider.do_post_logout_redirect(end_session_request) is None
+
+    def test_post_logout_redirect_with_unknown_post_logout_redirect_uri(self):
+        auth_req = AuthorizationRequest(response_type='code id_token token', scope='openid', client_id='client1',
+                                        redirect_uri='https://client.example.com/redirect')
+        auth_resp = self.provider.authorize(auth_req, 'user1')
+        end_session_request = EndSessionRequest(id_token_hint=auth_resp['id_token'],
+                                                post_logout_redirect_uri='https://client.example.com/unknown')
+        assert self.provider.do_post_logout_redirect(end_session_request) is None

--- a/tests/pyop/test_storage.py
+++ b/tests/pyop/test_storage.py
@@ -195,3 +195,40 @@ class TestMongoTTL(StorageTTLTest):
         with pytest.raises(ImportError):
             self.prepare_db("mongodb://localhost/0", None)
         pyop.storage._has_pymongo = True
+
+
+class TestStatelessWrapper(object):
+    @pytest.fixture
+    def db(self):
+        return pyop.storage.StatelessWrapper("pyop", "abc123")
+
+    def test_write(self, db):
+        db['foo'] = 'bar'
+        assert db['foo'] is None
+
+    def test_pack_and_unpack(self, db):
+        val_1 = {'foo': 'bar'}
+        key = db.pack(val_1)
+        val_2 = db[key]
+        assert val_1 == val_2
+
+    def test_pack_with_non_dict_val(self, db):
+        val_1 = 'this is not a dict'
+        key = db.pack(val_1)
+        val_2 = db[key]
+        assert val_1 == val_2
+
+    def test_contains(self, db):
+        val_1 = {'foo': 'bar'}
+        key = db.pack(val_1)
+        assert key in db
+
+    def test_items(self, db):
+        with pytest.raises(NotImplementedError):
+            db['foo'] = 'bar'
+            db.items()
+
+    def test_delitem(self, db):
+        with pytest.raises(NotImplementedError):
+            db['foo'] = 'bar'
+            del db['foo']


### PR DESCRIPTION
Added the capability of stateless code flow. If stateless flag is set to true, nothing is stored in the storage. The code and access token is embedded with the user_info which is required later for the evaluation of required claims.
