### PR TITLE
fix: ValueError should be raised, not returned

### DIFF
--- a/src/pyop/storage.py
+++ b/src/pyop/storage.py
@@ -93,7 +93,7 @@ class StorageBase(ABC):
                 alg=alg
             )
 
-        return ValueError(f"Invalid DB URI: {db_uri}")
+        raise ValueError(f"Invalid DB URI: {db_uri}")
 
     @classmethod
     def type(cls, db_uri):
@@ -105,7 +105,7 @@ class StorageBase(ABC):
         elif url.scheme == "stateless":
             return "stateless"
 
-        return ValueError(f"Invalid DB URI: {db_uri}")
+        raise ValueError(f"Invalid DB URI: {db_uri}")
 
     @property
     def ttl(self):


### PR DESCRIPTION
Fix an issue where invalid config might lead to an ValueError object being used as a databasse object, leading to application errors later.

Rather fail fast by properly raising the exception.