### PR TITLE
fix: auth_state: update db when marking code as used

### DIFF
--- a/src/pyop/authz_state.py
+++ b/src/pyop/authz_state.py
@@ -200,6 +200,7 @@ class AuthorizationState(object):
             raise InvalidAuthorizationCode('{} has expired'.format(authorization_code))
 
         authz_info['used'] = True
+        self.authorization_codes[authorization_code] = authz_info
 
         access_token = self._create_access_token(authz_info['sub'], authz_info[self.KEY_AUTHORIZATION_REQUEST],
                                                  authz_info['granted_scope'],


### PR DESCRIPTION
Store the updated `authz_info` info back into the database after marking the code as used.

Otherwise, the change would be discarded when using a DB (would hold only with in-memory dict)