### PR TITLE
fix: userinfo: avoid indexing by None user_id in  stateless mode

### DIFF
--- a/src/pyop/userinfo.py
+++ b/src/pyop/userinfo.py
@@ -31,6 +31,6 @@ class Userinfo(object):
         """
 
         if not userinfo:
-            userinfo = self._db[user_id]
+            userinfo = self._db[user_id] if user_id else {}
         claims = {claim: userinfo[claim] for claim in requested_claims if claim in userinfo}
         return claims


### PR DESCRIPTION
In stateless mode, `user_id` passed to `get_claims_for` is always `None`.

When no claims are available and userinfo is thus also `None`, `user_id` is used as index to self._db, but that triggers a `KeyError: None`.

As `create_access_token` populates `user_info` field in `authz_info` only of `user_info` is pythonically `True`, `user_info` passed here ends up being `None`, not empty dict `{}`.

As the `Userinfo` class does not have access to `Provider.stateless`, the easiest fix is to make the db lookup conditional on user_id being pythonically True - which corresponds with not being in stateltess mode.