### PR TITLE
Start migration to PyMongo 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'pycryptodomex',
     ],
     extras_require={
-        'mongo': 'pymongo',
+        'mongo': 'pymongo >= 3.12, < 4.0',
         'redis': 'redis',
     },
 )


### PR DESCRIPTION
Pin pyop to the latest version of PyMongo 3.x until it has completely migrated to PyMongo 4.  Most of the key new methods and options from PyMongo 4.0 are backported in PyMongo 3.12, making migration much easier.

Closes IdentityPython/pyop#51