### PR TITLE
Security fix: open redirect vulnerability in case of 'unknown client_id' 

### DIFF
--- a/src/pyop/exceptions.py
+++ b/src/pyop/exceptions.py
@@ -59,6 +59,11 @@ class InvalidAuthenticationRequest(InvalidRequestError):
         return None
 
 
+class UnknownClientId(InvalidAuthenticationRequest):
+    def to_error_url(self):
+        return None
+
+
 class InvalidRedirectURI(InvalidAuthenticationRequest):
     def to_error_url(self):
         return None

--- a/src/pyop/request_validator.py
+++ b/src/pyop/request_validator.py
@@ -5,6 +5,7 @@ from oic.oic import PREFERENCE2PROVIDER
 
 from .exceptions import InvalidClientRegistrationRequest
 from .exceptions import InvalidAuthenticationRequest
+from .exceptions import UnknownClientId
 from .exceptions import InvalidRedirectURI
 from .util import is_allowed_response_type, find_common_values
 
@@ -32,7 +33,7 @@ def client_id_is_known(provider, authentication_request):
     """
     if authentication_request['client_id'] not in provider.clients:
         logger.error('Unknown client_id \'{}\''.format(authentication_request['client_id']))
-        raise InvalidAuthenticationRequest('Unknown client_id',
+        raise UnknownClientId('Unknown client_id',
                                            authentication_request,
                                            oauth_error='unauthorized_client')
 


### PR DESCRIPTION
As outlined in https://github.com/IdentityPython/SATOSA/issues/498 , SATOSA returns a redirect to an unvalidated redirect_uri if the client is unknown, which is an "open redirect" vulnerability. The root cause is obviously in pyop, because it raises an InvalidAuthenticationRequest with a non-empty error_url if the client is unknown.

I have added a specific exception UnknownClientId which returns no error_url, just as the InvalidRedirectURI exception does.